### PR TITLE
회원가입 버그 수정

### DIFF
--- a/src/main/java/com/rainmaker/rainmaker/MultipartJackson2HttpMessageConverter.java
+++ b/src/main/java/com/rainmaker/rainmaker/MultipartJackson2HttpMessageConverter.java
@@ -1,0 +1,38 @@
+package com.rainmaker.rainmaker;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Type;
+
+/**
+ * multipart/form-data의 application/octet-stream 타입으로 들어온 json 을 읽기 위해 추가한 클래스
+ */
+@Component
+public class MultipartJackson2HttpMessageConverter extends AbstractJackson2HttpMessageConverter {
+
+    /**
+     * Converter for support http request with header Content-Type: multipart/form-data
+     */
+    public MultipartJackson2HttpMessageConverter(ObjectMapper objectMapper) {
+        super(objectMapper, MediaType.APPLICATION_OCTET_STREAM);
+    }
+
+    @Override
+    public boolean canWrite(Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    public boolean canWrite(Type type, Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    protected boolean canWrite(MediaType mediaType) {
+        return false;
+    }
+}

--- a/src/main/java/com/rainmaker/rainmaker/controller/AuthController.java
+++ b/src/main/java/com/rainmaker/rainmaker/controller/AuthController.java
@@ -34,15 +34,18 @@ public class AuthController {
     @Operation(
             summary = "회원가입 API",
             description = "<p>회원 정보를 바탕으로 회원 가입을 진행합니다.</p>" +
-                    "<p>이미지 파일을 보내지 않으면, 기본 프로필 이미지로 세팅됩니다.</p>" +
+                    "<p>multipart/form-data 형식의 input 을 받습니다.</p>" +
                     "<p>회원가입에 성공하면 회원가입된 사용자의 pk 를 응답합니다.</p>"
     )
     @PostMapping(
             value = "/local/new",
-            consumes = MediaType.MULTIPART_FORM_DATA_VALUE
+            consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE
     )
     public ResponseEntity<DataResponse<MemberCreateResponse>> signup(
+            @Parameter(description = "appliation/json 형식의 회원 정보를 입력받습니다.")
             @Valid @RequestPart MemberSignupRequest memberSignupRequest,
+            @Parameter(description = "이미지 파일을 보내지 않으면, 기본 프로필 이미지로 세팅됩니다.")
             @RequestParam(required = false) MultipartFile imageFile
     ) {
         Long memberId = authService.signUp(memberSignupRequest.toDto(), imageFile);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -62,7 +62,10 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
+      #      TODO 추후 create 및 sql init 제거 필요
       ddl-auto: create
+    defer-datasource-initialization: true
+  sql.init.mode: always
 
 ---
 # Settings for test


### PR DESCRIPTION
## 관련 이슈
- close #11 

## 작업 사항
- 포스트맨에서는 multipart/form-data 전송 시 memberSignupRequest 의 타입을 application/json 으로 세팅하여 테스트 성공하였으나 스웨거에서 세팅 불가능하여 스웨거 테스트 시application/octet-stream 을 읽지 못하는 문제 해결하였다.
- custom class 인 MultipartJackson2HttpMessageConverter 를 추가했다.


## 체크리스트

- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?