### PR TITLE
회원 가입 시 아이디(닉네임) 중복 체크 로직 추가

### DIFF
--- a/src/main/java/com/rainmaker/rainmaker/exception/ExceptionType.java
+++ b/src/main/java/com/rainmaker/rainmaker/exception/ExceptionType.java
@@ -1,6 +1,11 @@
 package com.rainmaker.rainmaker.exception;
 
+import com.rainmaker.rainmaker.exception.auth.JwtUnauthroziedException;
 import com.rainmaker.rainmaker.exception.common.CustomException;
+import com.rainmaker.rainmaker.exception.file.MultipartFileNotReadableException;
+import com.rainmaker.rainmaker.exception.member.MemberPKNotFoundException;
+import com.rainmaker.rainmaker.exception.member.NickNameDuplicateException;
+import com.rainmaker.rainmaker.exception.member.NickNameNotFoundException;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -10,7 +15,7 @@ import java.util.Objects;
 /**
  * Error code 규약
  * Member : 1XXX
- * 추후 추가 예정
+ * File : 2XXX
  */
 @AllArgsConstructor
 @Getter
@@ -19,7 +24,18 @@ public enum ExceptionType {
     UNHANDLED_EXCEPTION(0, "알 수 없는 서버 에러가 발생했습니다.", null),
     BAD_REQUEST_EXCEPTION(1, "요청 데이터가 잘못되었습니다.", null),
     ACCESS_DENIED_EXCEPTION(2, "권한이 유효하지 않습니다.", null),
-    AUTHENTICATION_EXCEPTION(3, "인증 과정에서 문제가 발생했습니다.", null);
+    AUTHENTICATION_EXCEPTION(3, "인증 과정에서 문제가 발생했습니다.", null),
+
+    // Auth
+    JWT_UNAUTHORIZED_EXCEPTION(100, "JWT 토큰이 잘못되었습니다.", JwtUnauthroziedException.class),
+
+    // Member
+    MEMBER_PK_NOT_FOUND_EXCEPTION(1000, "멤버 식별자로 멤버를 조회할 수 없습니다.", MemberPKNotFoundException.class),
+    NICKNAME_NOT_FOUND_EXCEPTION(1100, "해당 닉네임을 가지는 회원이 없습니다.", NickNameNotFoundException.class),
+    NICKNAME_DUPLICATE_EXCEPTION(1200, "이미 사용중인 닉네임입니다.", NickNameDuplicateException.class),
+
+    // File
+    MULTIPART_FILE_NOT_READABLE_EXCEPTION(2000, "multipart 파일을 읽을 수 없습니다.", MultipartFileNotReadableException.class);
 
     private final int errorCode;
     private final String errorMessage;

--- a/src/main/java/com/rainmaker/rainmaker/exception/major/MajorNotFoundException.java
+++ b/src/main/java/com/rainmaker/rainmaker/exception/major/MajorNotFoundException.java
@@ -1,0 +1,6 @@
+package com.rainmaker.rainmaker.exception.major;
+
+import com.rainmaker.rainmaker.exception.common.NotFoundException;
+
+public class MajorNotFoundException extends NotFoundException {
+}

--- a/src/main/java/com/rainmaker/rainmaker/exception/member/NickNameDuplicateException.java
+++ b/src/main/java/com/rainmaker/rainmaker/exception/member/NickNameDuplicateException.java
@@ -1,0 +1,6 @@
+package com.rainmaker.rainmaker.exception.member;
+
+import com.rainmaker.rainmaker.exception.common.ConflictException;
+
+public class NickNameDuplicateException extends ConflictException {
+}

--- a/src/main/java/com/rainmaker/rainmaker/repository/MajorRepository.java
+++ b/src/main/java/com/rainmaker/rainmaker/repository/MajorRepository.java
@@ -3,6 +3,8 @@ package com.rainmaker.rainmaker.repository;
 import com.rainmaker.rainmaker.entity.Major;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface MajorRepository extends JpaRepository<Major, Long> {
-    public Major findByName(String name);
+    public Optional<Major> findByName(String name);
 }

--- a/src/main/java/com/rainmaker/rainmaker/service/AuthService.java
+++ b/src/main/java/com/rainmaker/rainmaker/service/AuthService.java
@@ -5,6 +5,8 @@ import com.rainmaker.rainmaker.entity.Major;
 import com.rainmaker.rainmaker.entity.Member;
 import com.rainmaker.rainmaker.entity.ProfileImage;
 import com.rainmaker.rainmaker.exception.auth.JwtUnauthroziedException;
+import com.rainmaker.rainmaker.exception.major.MajorNotFoundException;
+import com.rainmaker.rainmaker.exception.member.NickNameDuplicateException;
 import com.rainmaker.rainmaker.exception.member.NickNameNotFoundException;
 import com.rainmaker.rainmaker.repository.MajorRepository;
 import com.rainmaker.rainmaker.repository.MemberRepository;
@@ -36,28 +38,53 @@ public class AuthService {
      */
     @Transactional
     public Long signUp(MemberDto memberDto, MultipartFile imageFile) {
-        // 프로필 이미지 생성
-        ProfileImage profileImage;
-        if (imageFile == null) { // 기본 프로필 이미지로 설정
-            if (profileImageRepository.existsDefaultMemberProfileImage()) {
-                profileImage = profileImageRepository.getDefaultMemberProfileImage();
-            } else {
-                profileImage = s3FileService.saveMemberDefaultProfileImage();
-            }
-        } else {
-            profileImage = s3FileService.saveFile(imageFile);
+
+        // 닉네임 중복 체크
+        if (memberRepository.findByNickName(memberDto.getNickName()).isPresent()) {
+            throw new NickNameDuplicateException();
         }
 
         // 학과 조회
-        Major major = majorRepository.findByName(memberDto.getMajorDto().getName());
+        Major major = majorRepository.findByName(memberDto.getMajorDto().getName())
+                .orElseThrow(MajorNotFoundException::new);
+
+        // 프로필 이미지 생성
+        ProfileImage profileImage = getProfileImage(imageFile);
 
         // 회원가입
         Member member = memberRepository.save(memberDto.toEntity(major, profileImage));
-
         member.encodePassword(passwordEncoder);
         member.addUserAuthority();
 
         return member.getId();
+    }
+
+    /**
+     * imageFile 이 null 이 아닐 경우, S3 에 저장하고 ProfileImage 를 생성한다.
+     * imageFile 이 null 일 경우, 기본 프로필 이미지의 ProfileImage 를 생성한다.
+     *
+     * @param imageFile 회원의 프로필 이미지로 설정하려는 이미지 파일
+     * @return 생성된 ProfileImage 객체
+     */
+    private ProfileImage getProfileImage(MultipartFile imageFile) {
+        if (imageFile == null) {
+            return getDefaultProfileImage();
+        } else {
+            return s3FileService.saveFile(imageFile);
+        }
+    }
+
+    /**
+     * 기본 프로필 이미지에 대해 ProfileImage 객체를 반환
+     *
+     * @return 기본 프로필 이미지의 ProfileImage 객체
+     */
+    private ProfileImage getDefaultProfileImage() {
+        if (profileImageRepository.existsDefaultMemberProfileImage()) {
+            return profileImageRepository.getDefaultMemberProfileImage();
+        } else {
+            return s3FileService.saveMemberDefaultProfileImage();
+        }
     }
 
     /**

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -46,6 +46,8 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create
+    database: mysql
+    database-platform: org.hibernate.dialect.MySQL5InnoDBDialect
     defer-datasource-initialization: true
   sql.init.mode: always
 
@@ -64,6 +66,8 @@ spring:
     hibernate:
       #      TODO 추후 create 및 sql init 제거 필요
       ddl-auto: create
+    database: mysql
+    database-platform: org.hibernate.dialect.MySQL5InnoDBDialect
     defer-datasource-initialization: true
   sql.init.mode: always
 

--- a/src/test/java/com/rainmaker/rainmaker/RainmakerApplicationTests.java
+++ b/src/test/java/com/rainmaker/rainmaker/RainmakerApplicationTests.java
@@ -2,12 +2,15 @@ package com.rainmaker.rainmaker;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 
+@ActiveProfiles("test")
 @SpringBootTest
+@TestPropertySource(locations = "classpath:/application.yml")
 class RainmakerApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
-
+    @Test
+    void contextLoads() {
+    }
 }

--- a/src/test/java/com/rainmaker/rainmaker/service/AuthServiceTest.java
+++ b/src/test/java/com/rainmaker/rainmaker/service/AuthServiceTest.java
@@ -18,6 +18,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.util.Optional;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -48,6 +50,7 @@ public class AuthServiceTest {
         given(profileImageRepository.existsDefaultMemberProfileImage()).willReturn(true);
         given(profileImageRepository.getDefaultMemberProfileImage()).willReturn(createProfileImage());
         given(memberRepository.save(any(Member.class))).willReturn(createMember());
+        given(majorRepository.findByName(anyString())).willReturn(Optional.of(createMajor()));
         given(passwordEncoder.encode(anyString())).willReturn("encodedPassword");
 
         //when


### PR DESCRIPTION
## 관련 이슈
- close #15 

## 작업 사항
- AuthService 의 회원가입 시 아이디 중복 체크 로직 추가
- 회원가입 코드 가독성 좋게 리팩토링
- application.yml 에서 MySQLDialct 설정 추가 (EC2 인스턴스에서 실행 시 에러를 해결하기 위해)

## 체크리스트

- [x]  PR의 제목은 팀 내 규칙을 준수하여 알맞게 작성하였는가?
- [x]  Merge 하는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x]  팀의 코딩 컨벤션을 준수하는가?
- [x]  PR과 관련없는 변경사항이 들어가지는 않았는가?
- [x]  내 코드에 대한 자기 검토가 되었는가?
- [x]  Reviewers, Assignees, Lables, Project, Milestone은 적절하게 선택하였는가?
- [x]  관련한 issue를 닫아야 하는지 점검해보고 적용했는가?